### PR TITLE
Update checkbox label font

### DIFF
--- a/TexasExes_FormAssemblyStyle.css
+++ b/TexasExes_FormAssemblyStyle.css
@@ -70,8 +70,9 @@
     line-height: 1.8em !important;
   }
 
-  /* Set the border around a field set form element */
+  /* Set the border around a field set form element and set the font family */
   .wFormContainer fieldset {
+    font-family: 'Rubik', sans-serif;
     border: 1px solid #ecede8;
   }
 


### PR DESCRIPTION
The checkbox labels were still appearing with Roboto font, so I updated the CSS to make sure they appear with Rubik.